### PR TITLE
ci(travis): prevent `release` stage running for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,45 @@
-language: node_js
-node_js: lts/*
+stages:
+  - commitlint
+  - name: release
+    if: branch = master AND type != pull_request
 
-install:
-  - npm install @commitlint/config-conventional -D
-  - npm install @commitlint/travis-cli -D
+jobs:
+  include:
+    # Define the commitlint stage
+    - stage: commitlint
+      language: node_js
+      node_js: lts/*
+      before_install: skip
+      script:
+        - npm install @commitlint/config-conventional -D
+        - npm install @commitlint/travis-cli -D
+        - commitlint-travis
+    # Define the release stage that runs semantic-release
+    - stage: release
+      language: node_js
+      node_js: lts/*
+      before_install: skip
+      script:
+        # Update `AUTHORS.md`
+        - export MAINTAINER_TOKEN=${GH_TOKEN}
+        - go get github.com/myii/maintainer
+        - maintainer contributor
 
-script:
-  - commitlint-travis
+        # Update Tables of Content in the relevant `.md` files
+        - npm install markdown-toc -D
+        - markdown-toc -i README.md
+
+        # Install all dependencies required for `semantic-release`
+        - npm install @semantic-release/changelog@3 -D
+        - npm install @semantic-release/exec@3 -D
+        - npm install @semantic-release/git@7 -D
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          # Run `semantic-release`
+          - npx semantic-release@15
+
 
 # jobs:
 #   include:


### PR DESCRIPTION
* The `release` stage will always fail due to security reasons:
  - E.g. https://travis-ci.com/saltstack-formulas/template-formula/jobs/180068519#L466.
  - Discussed: https://github.com/saltstack-formulas/template-formula/pull/42#issuecomment-466446324.
* The `release` stage is unnecessary, in any case.